### PR TITLE
Initial TeX workflow

### DIFF
--- a/.github/workflows/build-tex.yaml
+++ b/.github/workflows/build-tex.yaml
@@ -1,0 +1,105 @@
+name: Build SPHEREx TeX
+
+'on':
+  workflow_call:
+    inputs:
+      doc:
+        description: 'The document name, i.e. SSDC-MS-123'
+        required: true
+        type: string
+      upload:
+        description: 'Toggle to enable uploads to spherex-docs.ipac.caltech.edu'
+        required: false
+        default: true
+        type: boolean
+    secrets:
+      docs_api_password:
+        description: 'LTD password, usually the DOCS_API_PASSWORD org-wide secret.'
+        required: true
+
+jobs:
+  tex:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # full history for metadata
+          submodules: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.10'
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install -U pip
+          python -m pip install lander==2.0.0a7
+          python -m pip install git+https://github.com/SPHEREx/spherex-lander-plugin.git@main#egg=spherex-lander-plugin
+          python -m pip install ltd-conveyor==0.9.0a2
+
+      - name: Install pandoc
+        run: brew install pandoc # usually a newer pandoc than apt-get
+
+      - name: Get short SHA
+        uses: benjlevesque/short-sha@v1.2
+        id: short-sha
+
+      - name: Set version string
+        id: short-version
+        run: |
+          if [ $GITHUB_REF_TYPE == 'tag' ]; then
+              # version is a tag
+              echo "::set-output name=VERSION::${{ github.ref_name }}"
+          else
+              # For branch push events, use the SHA
+              echo '::set-output name=VERSION::${{ steps.short-sha.outputs.sha }}'
+          fi
+
+      - name: Set PDF filename
+        id: pdfname
+        run: echo '::set-output name=PDF_FILENAME::${{ inputs.doc }}.${{ steps.short-version.outputs.VERSION }}.pdf'
+
+      - name: Log into GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: token
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: TeX build
+        run: |
+          docker run -v `pwd`:/workspace -w /workspace ghcr.io/spherex/spherex-tex:latest sh -c 'make'
+
+      - name: Rename PDF
+        run: mv ${{ inputs.doc }}.pdf ${{ steps.pdfname.outputs.PDF_FILENAME }}
+
+      - name: Upload PDF artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{steps.pdfname.outputs.PDF_FILENAME }}
+          path: ${{steps.pdfname.outputs.PDF_FILENAME }}
+          retention-days: 14
+
+      - name: Build landing page
+        if: inputs.upload && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+        run: |
+          lander build --pdf ${{steps.pdfname.outputs.PDF_FILENAME }}
+
+      - name: Upload landing page
+        if: inputs.upload && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+        env:
+          LTD_PASSWORD: ${{ secrets.docs_api_password }}
+          LTD_USERNAME: spherex-upload
+          DOCNAME: ${{ inputs.doc }}
+        run: |
+          ltd --host https://docs-api.ipac.caltech.edu upload --org spherex --project ${DOCNAME,,} --gh --dir _build
+
+      - name: Upload release asset
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            ${{ steps.pdfname.outputs.PDF_FILENAME }}

--- a/.github/workflows/this.release.yaml
+++ b/.github/workflows/this.release.yaml
@@ -1,0 +1,13 @@
+name: Update Major Version Tag
+
+'on':
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  update-majorver:
+    name: Update Major Version Tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: nowactions/update-majorver@v1

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 SPHEREx
+Copyright (c) 2022 California Institute of Technology
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,2 +1,35 @@
 # spherex-doc-workflows
-GitHub Actions workflows for building SPHEREx documents
+
+[Reusable GitHub Actions workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows) for building SPHEREx documents.
+
+## build-tex.yaml
+
+The [build-tex.yaml](.github/workflows/build-tex.yaml) workflow builds SPHEREx tex documents and their landing pages, and uploads to [spherex-docs.ipac.caltech.edu](https://spherex-docs.ipac.caltech.edu). This workflow is compatible with builds triggered by `push`, `pull_request`, and `workflow_dispatch` triggers. When a tag is pushed, this workflow also creates/updates a corresponding GitHub Release with the built PDF.
+
+Example calling workflow:
+
+```yaml
+name: CI
+
+'on':
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build-tex:
+    uses: SPHEREx/spherex-doc-workflows/.github/workflows/build-tex.yaml@v1
+    with:
+      doc: SSDC-MS-001
+    secrets:
+      docs_api_password: ${{ secrets.SPHEREX_DOCS_API_PASSWORD }}
+```
+
+### Inputs
+
+- `doc` (string, required). This is the document's identifier, which also matches the filename of the `.tex` document. For example, `SSDC-MS-001`.
+- `upload` (boolean, optional). This input can be set to `false` to disable uploads to spherex-docs.ipac.caltech.edu. The default behavior is to upload on `push` and `workflow_dispatch` events.
+
+### Secrets
+
+- `docs_api_password` (required). The password for the `spherex-upload` user for `docs-api.ipac.caltech.edu`.


### PR DESCRIPTION
In order to simplify the build infrastructure of individual documents as much as possible, we can adopt GitHub's new "reusable workflows" feature. Individual document's GitHub Actions workflows can call this workflow to build the TeX document and upload it (to the docs platform, to workflow artifacts, and to release assets). Another feature of this reusable workflow is that it works both for branch push and for tag pushes (on tag pushes it uploads a release artifact).