### PR TITLE
Install pandoc via debian package

### DIFF
--- a/.github/workflows/build-tex.yaml
+++ b/.github/workflows/build-tex.yaml
@@ -40,8 +40,12 @@ jobs:
           python -m pip install git+https://github.com/SPHEREx/spherex-lander-plugin.git@main#egg=spherex-lander-plugin
           python -m pip install ltd-conveyor==0.9.0a2
 
-      - name: Install pandoc
-        run: brew install pandoc # usually a newer pandoc than apt-get
+      - name: Install Pandoc
+        run: |
+          downloadUrl="https://github.com/jgm/pandoc/releases/download/2.19.2/pandoc-2.19.2-1-amd64.deb"
+          wget --no-verbose "$downloadUrl"
+          sudo dpkg -i "${downloadUrl##*/}"
+          pandoc --version
 
       - name: Get short SHA
         uses: benjlevesque/short-sha@v1.2


### PR DESCRIPTION
We've found that brew (Homebrew) is no longer present by default in GitHub Actions Ubuntu workers. This PR replaces the pandoc installation via homebrew with a direct installation from the Debian package included in Pandoc's GitHub release assets.

An advantage of this approach is that we can now specifically set the pandoc version being used, and update it based on
https://github.com/jgm/pandoc/releases