### PR TITLE
Install lander via spherex-lander-plugin deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,3 +2,5 @@ version: 2
 updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
+    schedule:
+      interval: 'daily'

--- a/.github/workflows/build-tex.yaml
+++ b/.github/workflows/build-tex.yaml
@@ -36,8 +36,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install -U pip
-          python -m pip install lander==2.0.0a7
-          python -m pip install git+https://github.com/SPHEREx/spherex-lander-plugin.git@main#egg=spherex-lander-plugin
+          python -m pip install "spherex-lander-plugin @ git+https://github.com/SPHEREx/spherex-lander-plugin.git@main"
           python -m pip install ltd-conveyor==0.9.0a2
 
       - name: Install Pandoc


### PR DESCRIPTION
By dropping the explicit dependency on lander here, we allow spherex-lander-plugin to set what version of lander it's compatible with.

See https://github.com/SPHEREx/spherex-lander-plugin/pull/12