### PR TITLE
Fix "dirty" state in PDF builds

### DIFF
--- a/.github/workflows/build-tex.yaml
+++ b/.github/workflows/build-tex.yaml
@@ -23,13 +23,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0 # full history for metadata
           submodules: true
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
 
@@ -48,7 +48,7 @@ jobs:
           pandoc --version
 
       - name: Get short SHA
-        uses: benjlevesque/short-sha@v2.1
+        uses: benjlevesque/short-sha@v3.0
         id: short-sha
 
       - name: Set version string
@@ -67,7 +67,7 @@ jobs:
         run: echo "PDF_FILENAME=${{ inputs.doc }}.${{ steps.short-version.outputs.VERSION }}.pdf" >> $GITHUB_OUTPUT
 
       - name: Log into GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: token
@@ -81,7 +81,7 @@ jobs:
         run: mv ${{ inputs.doc }}.pdf ${{ steps.pdfname.outputs.PDF_FILENAME }}
 
       - name: Upload PDF artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{steps.pdfname.outputs.PDF_FILENAME }}
           path: ${{steps.pdfname.outputs.PDF_FILENAME }}
@@ -103,7 +103,7 @@ jobs:
 
       - name: Upload release asset
         if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: |
             ${{ steps.pdfname.outputs.PDF_FILENAME }}

--- a/.github/workflows/build-tex.yaml
+++ b/.github/workflows/build-tex.yaml
@@ -44,6 +44,7 @@ jobs:
           downloadUrl="https://github.com/jgm/pandoc/releases/download/2.19.2/pandoc-2.19.2-1-amd64.deb"
           wget --no-verbose "$downloadUrl"
           sudo dpkg -i "${downloadUrl##*/}"
+          rm "pandoc-2.19.2-1-amd64.deb"
           pandoc --version
 
       - name: Get short SHA


### PR DESCRIPTION
The PDF builds include a flag, computed through `meta.tex` of whether the repo is in a dirty state or not. One source of this dirty state is the pandoc binary package that the workflow downloads to install pandoc. This package is now deleted automatically after pandoc is installed, and therefor provides a clean Git state for the LaTeX build to occur in.

The other issue is that the latex build creates an `.xdv` file, which can only be resolved through an addition to `.gitignore` — however this "dirty" state only occurs _after_ the LaTeX build and therefore does not impact the version string calculation in `meta.tex`.

Besides this fix, the versions of dependent actions are also updated here:

 - actions/checkout v3 -> v4
 - actions/setup-python v4 -> v5
 - benjlevesque/short-sha v2.1 -> v3.0
 - docker/login-action v2 -> v3
 - actions/upload-artifact v3 -> v4
 - softprops/action-gh-release v1 -> v2