### PR TITLE
Create reusable workflow for sphinx technotes

### DIFF
--- a/.github/workflows/build-sphinx-technote.yaml
+++ b/.github/workflows/build-sphinx-technote.yaml
@@ -39,9 +39,6 @@ jobs:
           python -m pip install ltd-conveyor==0.9.0a2
 
       - name: Run tox
-        run: tox run -e html
-
-      - name: Run tox
         uses: lsst-sqre/run-tox@v1
         with:
           python-version: "3.12"

--- a/.github/workflows/build-sphinx-technote.yaml
+++ b/.github/workflows/build-sphinx-technote.yaml
@@ -1,0 +1,57 @@
+name: Build SPHEREx Sphinx Technote
+
+"on":
+  workflow_call:
+    inputs:
+      doc:
+        description: "The document name, i.e. SSDC-TN-123"
+        required: true
+        type: string
+      upload:
+        description: "Toggle to enable uploads to spherex-docs.ipac.caltech.edu"
+        required: false
+        default: true
+        type: boolean
+    secrets:
+      docs_api_password:
+        description: "LTD password, usually the DOCS_API_PASSWORD org-wide secret."
+        required: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # full history for metadata
+          submodules: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install -U pip
+          python -m pip install ltd-conveyor==0.9.0a2
+
+      - name: Run tox
+        run: tox run -e html
+
+      - name: Run tox
+        uses: lsst-sqre/run-tox@v1
+        with:
+          python-version: "3.12"
+          tox-envs: "html"
+
+      - name: Upload
+        if: inputs.upload && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+        env:
+          LTD_PASSWORD: ${{ secrets.docs_api_password }}
+          LTD_USERNAME: spherex-upload
+          DOCNAME: ${{ inputs.doc }}
+        run: |
+          ltd --host https://docs-api.ipac.caltech.edu upload --org spherex --project ${DOCNAME,,} --gh --dir _build

--- a/README.md
+++ b/README.md
@@ -2,6 +2,38 @@
 
 [Reusable GitHub Actions workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows) for building SPHEREx documents.
 
+## build-sphinx-technote.yaml
+
+The [build-sphinx-technote.yaml](.github/workflows/build-sphinx-technote.yaml) workflow builds SPHEREx Sphinx-based technotes (Markdown, reStructuredText, or ipynb-formatted), and uploads to [spherex-docs.ipac.caltech.edu](https://spherex-docs.ipac.caltech.edu). This workflow is compatible with builds triggered by `push`, `pull_request`, and `workflow_dispatch` triggers.
+
+Example calling workflow:
+
+```yaml
+name: CI
+
+"on":
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    uses: SPHEREx/spherex-doc-workflows/.github/workflows/build-sphinx-technote.yaml@v1
+    with:
+      doc: SSDC-TN-001
+    secrets:
+      docs_api_password: ${{ secrets.SPHEREX_DOCS_API_PASSWORD }}
+```
+
+### Inputs
+
+- `doc` (string, required). This is the document's identifier, which also matches the filename of the `.tex` document. For example, `SSDC-TN-001`.
+- `upload` (boolean, optional). This input can be set to `false` to disable uploads to spherex-docs.ipac.caltech.edu. The default behavior is to upload on `push` and `workflow_dispatch` events.
+
+### Secrets
+
+- `docs_api_password` (required). The password for the `spherex-upload` user for `docs-api.ipac.caltech.edu`.
+
 ## build-tex.yaml
 
 The [build-tex.yaml](.github/workflows/build-tex.yaml) workflow builds SPHEREx tex documents and their landing pages, and uploads to [spherex-docs.ipac.caltech.edu](https://spherex-docs.ipac.caltech.edu). This workflow is compatible with builds triggered by `push`, `pull_request`, and `workflow_dispatch` triggers. When a tag is pushed, this workflow also creates/updates a corresponding GitHub Release with the built PDF.
@@ -11,7 +43,7 @@ Example calling workflow:
 ```yaml
 name: CI
 
-'on':
+"on":
   push:
   pull_request:
   workflow_dispatch:


### PR DESCRIPTION
This `build-sphinx-technote.yaml` workflow provides common tooling for building and uploading any Sphinx-based technote document (Markdown, reStructuredText, or ipynb). It run's the tox file in the templated technote repository to build the HTML site and uses ltd-upload to upload the document.